### PR TITLE
bump version to '2.1.1-r0'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,17 @@ FROM gcr.io/stacksmith-images/ubuntu:14.04-r9
 MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_APP_NAME=magento \
-    BITNAMI_IMAGE_VERSION=2.0.5-r2 \
+    BITNAMI_IMAGE_VERSION=2.1.1-r0 \
     PATH=/opt/bitnami/php/bin:/opt/bitnami/apache/bin:/opt/bitnami/magento/bin/:$PATH
 
 # Additional modules required
-RUN bitnami-pkg unpack apache-2.4.23-2 --checksum be3c28581f363e240f04c2d32bcf2d4a5ea0926722bb23ab9f5dfb38bde22bac
-RUN bitnami-pkg unpack php-7.0.8-0 --checksum afc462c63a44a1abe5c130d1fdfad3ef88989b8b75d782c90538a0d1acaff4ee
-RUN bitnami-pkg install libphp-7.0.6-0 --checksum ab1ae095760d5a5d45a232a6b22cca40d3a5fc9116ddc73cc535f740dbf99e46
+RUN bitnami-pkg unpack apache-2.4.23-3 --checksum b75ced97d6b6f9dd8d0114ee0ca3943250af6edc91a20857f68165e4bf7d35fa
+RUN bitnami-pkg install php-7.0.11-0 --checksum 7c8203e315d4adba00d7b80ec8b527e572a47e7739a1d0d23ca348eef3d4093a
+RUN bitnami-pkg install libphp-7.0.11-0 --checksum 5607228fc09750339e75df85807592f5c24d1844d924d2a5acb2bc2b138e4984
 RUN bitnami-pkg install mysql-client-10.1.13-4 --checksum 14b45c91dd78b37f0f2366712cbe9bfdf2cb674769435611955191a65dbf4976
 
 # Install magento
-RUN bitnami-pkg unpack magento-2.0.5-1 --checksum 7c9aaf1f5f1dcd1f23d6b96b61edace39b72217f0ad98eb9b4bb001476efa36d
+RUN bitnami-pkg unpack magento-2.1.1-1 --checksum 744c18a9c3074211f170db6741bcd96e5c66aa3e31ca7445d6f845bdd83a6110
 
 COPY rootfs /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV BITNAMI_APP_NAME=magento \
 
 # Additional modules required
 RUN bitnami-pkg unpack apache-2.4.23-3 --checksum b75ced97d6b6f9dd8d0114ee0ca3943250af6edc91a20857f68165e4bf7d35fa
-RUN bitnami-pkg install php-7.0.11-0 --checksum 7c8203e315d4adba00d7b80ec8b527e572a47e7739a1d0d23ca348eef3d4093a
+RUN bitnami-pkg unpack php-7.0.11-0 --checksum 7c8203e315d4adba00d7b80ec8b527e572a47e7739a1d0d23ca348eef3d4093a
 RUN bitnami-pkg install libphp-7.0.11-0 --checksum 5607228fc09750339e75df85807592f5c24d1844d924d2a5acb2bc2b138e4984
 RUN bitnami-pkg install mysql-client-10.1.13-4 --checksum 14b45c91dd78b37f0f2366712cbe9bfdf2cb674769435611955191a65dbf4976
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
       - 'magento_data:/bitnami/magento'
       - 'apache_data:/bitnami/apache'
       - 'php_data:/bitnami/php'
-    environment:
-      - MAGENTO_HOST=localhost
     depends_on:
       - mariadb
 volumes:


### PR DESCRIPTION
Dockerfile: `apache-2.4.23-3`, `php-7.0.11-0` and `libphp-7.0.11-0` module update
docker-compose.yml: remove `MAGENTO_HOST` env var. It is defaulted to `127.0.0.1` in the module itself