### PR TITLE
Unify instructions in nami modules documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Running Magento with a database server is the recommended way. You can either us
 
 This is the recommended way to run Magento. You can use the following docker compose template:
 
-```
+```yaml
 version: '2'
 
 services:
@@ -58,13 +58,13 @@ If you want to run the application manually instead of using docker-compose, the
 
 1. Create a new network for the application and the database:
 
-  ```
+  ```bash
   $ docker network create magento_network
   ```
 
 2. Start a MariaDB database in the network generated:
 
-  ```
+  ```bash
   $ docker run -d --name mariadb --net=magento_network bitnami/mariadb
   ```
 
@@ -72,7 +72,7 @@ If you want to run the application manually instead of using docker-compose, the
 
 3. Run the Magento container:
 
-  ```
+  ```bash
   $ docker run -d -p 80:80 --name magento --net=magento_network bitnami/magento
   ```
 
@@ -93,7 +93,8 @@ To avoid inadvertent removal of these volumes you can [mount host directories as
 ### Mount host directories as data volumes with Docker Compose
 
 This requires a minor change to the `docker-compose.yml` template previously shown:
-```
+
+```yaml
 version: '2'
 
 services:
@@ -121,13 +122,13 @@ In this case you need to specify the directories to mount on the run command. Th
 
 1. Create a network (if it does not exist):
 
-  ```
+  ```bash
   $ docker network create magento-tier
   ```
 
 2. Create a MariaDB container with host volume:
 
-  ```
+  ```bash
   $ docker run -d --name mariadb \
     --net magento-tier \
     --volume /path/to/mariadb-persistence:/bitnami/mariadb \
@@ -138,7 +139,7 @@ In this case you need to specify the directories to mount on the run command. Th
 
 3. Create the Magento container with host volumes:
 
-  ```
+  ```bash
   $ docker run -d --name magento -p 80:80 -p 443:443 \
     --net magento-tier \
     --volume /path/to/magento-persistence:/bitnami/magento \
@@ -153,7 +154,7 @@ Bitnami provides up-to-date versions of MariaDB and Magento, including security 
 
 1. Get the updated images:
 
-  ```
+  ```bash
   $ docker pull bitnami/magento:latest
   ```
 
@@ -179,7 +180,7 @@ Bitnami provides up-to-date versions of MariaDB and Magento, including security 
  When you start the magento image, you can adjust the configuration of the instance by passing one or more environment variables either on the docker-compose file or on the docker run command line. If you want to add a new environment variable:
 
  * For docker-compose add the variable name and value under the application section:
-```
+```yaml
 application:
   image: bitnami/magento:latest
   ports:
@@ -192,7 +193,7 @@ application:
 
  * For manual execution add a `-e` option with each variable and value:
 
-```
+```bash
  $ docker run -d -e MAGENTO_PASSWORD=my_password1234 -p 80:80 --name magento -v /your/local/path/bitnami/magento:/bitnami/magento --net=magento_network bitnami/magento
 ```
 
@@ -222,7 +223,7 @@ To backup your application data follow these steps:
 
 2. Copy the Magento data folder in the host:
 
-  ```
+  ```bash
   $ docker cp /your/local/path/bitnami:/bitnami/magento
   ```
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,15 @@ Then you can access your application at http://your-ip/
 
 ## Persisting your application
 
-If you remove every container and volume all your data will be lost, and the next time you run the image the application will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed. If you are using docker-compose your data will be persistent as long as you don't remove `mariadb_data` and `application_data` data volumes. If you have run the containers manually or you want to mount the folders with persistent data in your host follow the next steps:
+If you remove every container and volume all your data will be lost, and the next time you run the image the application will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed. 
+
+For persistence of the Magento deployment, the above examples define docker volumes namely `mariadb_data`, `magento_data`, `apache_data` and `php_data`. The Magento application state will persist as long as these volumes are not removed.
 
 > **Note!** If you have already started using your application, follow the steps on [backing](#backing-up-your-application) up to pull the data from your running container down to your host.
 
-### Mount persistent folders in the host using docker-compose
+### Mount host directories as data volumes with Docker Compose
 
-This requires a sightly modification from the template previously shown:
+This requires a sightly modification from the `docker-compose.yml` template previously shown:
 ```
 version: '2'
 
@@ -96,42 +98,51 @@ services:
   mariadb:
     image: 'bitnami/mariadb:latest'
     volumes:
-      - '/path/to/your/local/mariadb_data:/bitnami/mariadb'
+      - '/path/to/mariadb_data:/bitnami/mariadb'
   application:
     image: 'bitnami/magento:latest'
+    depends_on:
+      - mariadb
     ports:
       - '80:80'
       - '443:443'
     volumes:
-      - '/path/to/your/local/magento_data:/bitnami/magento'
-      - '/path/to/your/local/php_data:/bitnami/php'
-      - '/path/to/your/local/apache_data:/bitnami/apache'
-    depends_on:
-      - mariadb
+      - '/path/to/magento-persistence:/bitnami/magento'
+      - '/path/to/php-persistence:/bitnami/php'
+      - '/path/to/apache-persistence:/bitnami/apache'
+    
 ```
 
-### Mount persistent folders manually
+### Mount host directories as data volumes using the Docker command line
 
 In this case you need to specify the directories to mount on the run command. The process is the same than the one previously shown:
 
-1. If you haven't done this before, create a new network for the application and the database:
+1. Create a network (if it does not exist):
 
   ```
-  $ docker network create magento_network
+  $ docker network create magento
   ```
 
-2. Start a MariaDB database in the previous network:
+2. Create a MariaDB container with host volume:
 
   ```
-  $ docker run -d --name mariadb -v /your/local/path/bitnami/mariadb_data:/bitnami/mariadb  --net=magento_network bitnami/mariadb
+  $ docker run -d --name mariadb \
+    --net magento \
+    --volume /path/to/mariadb-persistence:/bitnami/mariadb \
+    bitnami/mariadb:latest
   ```
 
   *Note:* You need to give the container a name in order to Magento to resolve the host
 
-3. Run the Magento container:
+3. Create the Joomla container with host volumes:
 
   ```
-  $ docker run -d -p 80:80 --name magento -v /your/local/path/bitnami/magento:/bitnami/magento --net=magento_network bitnami/magento
+  $ docker run -d --name magento -p 80:80 -p 443:443 \
+    --net magento \
+    --volume /path/to/magento-persistence:/bitnami/magento \
+    --volume /path/to/apache-persistence:/bitnami/apache \
+    --volume /path/to/php-persistence:/bitnami/php \
+    bitnami/magento:latest
   ```
 
 # Upgrade this application

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ In this case you need to specify the directories to mount on the run command. Th
 
   *Note:* You need to give the container a name in order to Magento to resolve the host
 
-3. Create the Joomla container with host volumes:
+3. Create the Magento container with host volumes:
 
   ```
   $ docker run -d --name magento -p 80:80 -p 443:443 \

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ If you want to run the application manually instead of using docker-compose, the
 1. Create a new network for the application and the database:
 
   ```bash
-  $ docker network create magento_network
+  $ docker network create magento-tier
   ```
 
 2. Start a MariaDB database in the network generated:
 
   ```bash
-  $ docker run -d --name mariadb --net=magento_network bitnami/mariadb
+  $ docker run -d --name mariadb --net=magento-tier bitnami/mariadb
   ```
 
   *Note:* You need to give the container a name in order to Magento to resolve the host
@@ -73,7 +73,7 @@ If you want to run the application manually instead of using docker-compose, the
 3. Run the Magento container:
 
   ```bash
-  $ docker run -d -p 80:80 --name magento --net=magento_network bitnami/magento
+  $ docker run -d -p 80:80 --name magento --net=magento-tier bitnami/magento
   ```
 
 Then you can access your application at http://your-ip/
@@ -82,7 +82,7 @@ Then you can access your application at http://your-ip/
 
 ## Persisting your application
 
-If you remove every container and volume all your data will be lost, and the next time you run the image the application will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed. 
+If you remove every container and volume all your data will be lost, and the next time you run the image the application will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
 
 For persistence of the Magento deployment, the above examples define docker volumes namely `mariadb_data`, `magento_data`, `apache_data` and `php_data`. The Magento application state will persist as long as these volumes are not removed.
 
@@ -101,7 +101,7 @@ services:
   mariadb:
     image: 'bitnami/mariadb:latest'
     volumes:
-      - '/path/to/mariadb_data:/bitnami/mariadb'
+      - /path/to/mariadb-persistence:/bitnami/mariadb
   magento:
     image: 'bitnami/magento:latest'
     depends_on:
@@ -113,7 +113,7 @@ services:
       - '/path/to/magento-persistence:/bitnami/magento'
       - '/path/to/php-persistence:/bitnami/php'
       - '/path/to/apache-persistence:/bitnami/apache'
-    
+
 ```
 
 ### Mount host directories as data volumes using the Docker command line
@@ -194,7 +194,7 @@ application:
  * For manual execution add a `-e` option with each variable and value:
 
 ```bash
- $ docker run -d -e MAGENTO_PASSWORD=my_password1234 -p 80:80 --name magento -v /your/local/path/bitnami/magento:/bitnami/magento --net=magento_network bitnami/magento
+ $ docker run -d -e MAGENTO_PASSWORD=my_password1234 -p 80:80 --name magento -v /your/local/path/bitnami/magento:/bitnami/magento --net=magento-tier bitnami/magento
 ```
 
 Available variables:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To avoid inadvertent removal of these volumes you can [mount host directories as
 
 ### Mount host directories as data volumes with Docker Compose
 
-TThis requires a minor change to the `docker-compose.yml` template previously shown:
+This requires a minor change to the `docker-compose.yml` template previously shown:
 ```
 version: '2'
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ If you remove every container and volume all your data will be lost, and the nex
 
 For persistence of the Magento deployment, the above examples define docker volumes namely `mariadb_data`, `magento_data`, `apache_data` and `php_data`. The Magento application state will persist as long as these volumes are not removed.
 
+To avoid inadvertent removal of these volumes you can [mount host directories as data volumes](https://docs.docker.com/engine/tutorials/dockervolumes/). Alternatively you can make use of volume plugins to host the volume data.
+
 > **Note!** If you have already started using your application, follow the steps on [backing](#backing-up-your-application) up to pull the data from your running container down to your host.
 
 ### Mount host directories as data volumes with Docker Compose
 
-This requires a sightly modification from the `docker-compose.yml` template previously shown:
+TThis requires a minor change to the `docker-compose.yml` template previously shown:
 ```
 version: '2'
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ services:
     image: 'bitnami/mariadb:latest'
     volumes:
       - '/path/to/mariadb_data:/bitnami/mariadb'
-  application:
+  magento:
     image: 'bitnami/magento:latest'
     depends_on:
       - mariadb
@@ -120,14 +120,14 @@ In this case you need to specify the directories to mount on the run command. Th
 1. Create a network (if it does not exist):
 
   ```
-  $ docker network create magento
+  $ docker network create magento-tier
   ```
 
 2. Create a MariaDB container with host volume:
 
   ```
   $ docker run -d --name mariadb \
-    --net magento \
+    --net magento-tier \
     --volume /path/to/mariadb-persistence:/bitnami/mariadb \
     bitnami/mariadb:latest
   ```
@@ -138,7 +138,7 @@ In this case you need to specify the directories to mount on the run command. Th
 
   ```
   $ docker run -d --name magento -p 80:80 -p 443:443 \
-    --net magento \
+    --net magento-tier \
     --volume /path/to/magento-persistence:/bitnami/magento \
     --volume /path/to/apache-persistence:/bitnami/apache \
     --volume /path/to/php-persistence:/bitnami/php \


### PR DESCRIPTION
-Add components as persistent volumes
-In order to be consistent, some sentences are changed by taking
Wordpress as a model.