### PR TITLE
Fix non-root permission issue

### DIFF
--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -139,6 +139,13 @@ items:
         labels:
           io.kompose.service: mariadb
       spec:
+        initContainers:
+        - name: volume-permissions
+          image: busybox
+          command: ['sh', '-c', 'chmod -R g+rwX /bitnami']
+          volumeMounts:
+          - mountPath: /bitnami
+            name: magento-mariadb-data
         containers:
         - env:
           - name: ALLOW_EMPTY_PASSWORD


### PR DESCRIPTION
**Description of the change**

This change applies the fix to the mounted volume for mariadb as in its [parent](https://github.com/bitnami/bitnami-docker-mariadb/commit/d37c484e05d3f4b380de2ff215384e51df68ea75).

**Benefits**

After applying the fix, the command `kubectl create -f kubernetes.yml` will successfully create the stack on GKE.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
