### PR TITLE
Add readability check for environement variable files

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/magento-env.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/magento-env.sh
@@ -15,6 +15,9 @@ export BITNAMI_VOLUME_DIR="/bitnami"
 export MODULE="${MODULE:-magento}"
 export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 
+# Load logging library
+. /opt/bitnami/scripts/liblog.sh
+
 # By setting an environment variable matching *_FILE to a file path, the prefixed environment
 # variable will be overridden with the value specified in that file
 magento_env_vars=(
@@ -72,8 +75,12 @@ magento_env_vars=(
 for env_var in "${magento_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
     if [[ -n "${!file_env_var:-}" ]]; then
-        export "${env_var}=$(< "${!file_env_var}")"
-        unset "${file_env_var}"
+        if [[ -r "${!file_env_var:-}" ]]; then
+            export "${env_var}=$(< "${!file_env_var}")"
+            unset "${file_env_var}"
+        else
+            warn "${!file_env_var:-} is not readable."
+        fi
     fi
 done
 unset magento_env_vars

--- a/2/debian-10/rootfs/opt/bitnami/scripts/magento-env.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/magento-env.sh
@@ -8,15 +8,15 @@
 # 3. Environment variables overridden via external files using *_FILE variables (see below)
 # 4. Environment variables set externally (i.e. current Bash context/Dockerfile/userdata)
 
+# Load logging library
+. /opt/bitnami/scripts/liblog.sh
+
 export BITNAMI_ROOT_DIR="/opt/bitnami"
 export BITNAMI_VOLUME_DIR="/bitnami"
 
 # Logging configuration
 export MODULE="${MODULE:-magento}"
 export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
-
-# Load logging library
-. /opt/bitnami/scripts/liblog.sh
 
 # By setting an environment variable matching *_FILE to a file path, the prefixed environment
 # variable will be overridden with the value specified in that file
@@ -79,7 +79,7 @@ for env_var in "${magento_env_vars[@]}"; do
             export "${env_var}=$(< "${!file_env_var}")"
             unset "${file_env_var}"
         else
-            warn "${!file_env_var:-} is not readable."
+            warn "Skipping export of '${env_var}'. '${!file_env_var:-}' is not readable."
         fi
     fi
 done


### PR DESCRIPTION
**Description of the change**
- Adds a readability check for environment variables loaded as file (with  `<VARIABLE_NAME>_FILE`).
- Issues a warning when the file is not readable.

**Benefits**
Better user experience

**Possible drawbacks**
/

**Applicable issues**
Fixes #179 

**Additional information**
I used `/opt/bitnami/scripts/liblog.sh` to issue the warning.