### PR TITLE
Update post-init.sh to include sorting

### DIFF
--- a/2/debian-10/rootfs/post-init.sh
+++ b/2/debian-10/rootfs/post-init.sh
@@ -9,7 +9,7 @@ set -o pipefail
 
 # Only execute init scripts once
 if [[ ! -f "/bitnami/magento/.user_scripts_initialized" && -d "/docker-entrypoint-init.d" ]]; then
-    read -r -a init_scripts <<< "$(find "/docker-entrypoint-init.d" -type f -print0 | xargs -0)"
+    read -r -a init_scripts <<< "$(find "/docker-entrypoint-init.d" -type f -print0 | sort -z | xargs -0)"
     if [[ "${#init_scripts[@]}" -gt 0 ]] && [[ ! -f "/bitnami/magento/.user_scripts_initialized" ]]; then
         mkdir -p "/bitnami/magento"
         for init_script in "${init_scripts[@]}"; do


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

By adding a sort we can name our init scripts in numerical order to have them processed in a predictable manner. 

E.g. the following files will be run in correct order:
01-must-be-run-first.sh
02-must-be-run-second.sh
99-will-be-run-last.sh

**Benefits**

Very useful in case some init scripts need to be run before others.