### PR TITLE
Update elasticsearch version in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - mariadb
       - elasticsearch
   elasticsearch:
-    image: docker.io/bitnami/elasticsearch:6
+    image: docker.io/bitnami/elasticsearch:7.13.3-debian-10-r0
     volumes:
       - 'elasticsearch_data:/bitnami/elasticsearch/data'
 volumes:


### PR DESCRIPTION
**Description of the change**
After spending the afternoon trying to figure out why my local magento was unable to search for any products, I discovered it was due to an incompatibility with elasticsearch 6.

This change just bumps the elasticsearch version to match the same version used in the helm charts: https://github.com/bitnami/charts/blob/master/bitnami/elasticsearch/values.yaml#L23

**Benefits**

Local setup better matches helm charts, avoid compatibility issues.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

[Magento System Requirements](https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html)
