### PR TITLE
Change description of the MAGENTO_SKIP_BOOTSTRAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Available environment variables:
 - `MAGENTO_ENABLE_ADMIN_HTTPS`: Whether to use SSL to access the Magento Admin. Valid values: yes, no. Default: **no**
 - `MAGENTO_DEPLOY_STATIC_CONTENT`: Whether to deploy Magento static content during the initialization, to optimize initial page load time. Default: **no**
 - `MAGENTO_SKIP_REINDEX`: Whether to skip Magento re-index during the initialization. Default: **no**
-- `MAGENTO_SKIP_BOOTSTRAP`: Whether to perform initial bootstrapping for the application. Default: **no**
+- `MAGENTO_SKIP_BOOTSTRAP`: Whether to skip performing the initial bootstrapping for the application. Default: **no**
 
 ##### HTTP cache server
 


### PR DESCRIPTION
**Description of the change**
Change the description of MAGENTO_SKIP_BOOTSTRAP.
Currently the description have the opposite meaning of the flag name.
The flag name says if the value is "yes" then the bootstrap is skipped. But the description says if the value is "yes" then bootstrap is not skipped.

**Benefits**
Provide correct explanation of the flag function.

**Possible drawbacks**
None

**Applicable issues**
None

**Additional information**
None
